### PR TITLE
Populate pidgin Mattermost group with buddies from server.

### DIFF
--- a/libmattermost.c
+++ b/libmattermost.c
@@ -1149,7 +1149,7 @@ mm_get_users_by_ids_response(MattermostAccount *ma, JsonNode *node, gpointer use
 	GList *i;
 
 	for (i=user_data;i;i=i->next) {
-        mm_user = i->data;
+		mm_user = i->data;
 		JsonObject *user = json_object_get_object_member(response,mm_user->user_id);
 		if (user != NULL) {			
 			const gchar *username = json_object_get_string_member(user, "username");
@@ -1161,6 +1161,8 @@ mm_get_users_by_ids_response(MattermostAccount *ma, JsonNode *node, gpointer use
 				g_hash_table_replace(ma->one_to_ones, g_strdup(mm_user->user_id), g_strdup(username));
 				g_hash_table_replace(ma->one_to_ones_rev, g_strdup(username), g_strdup(mm_user->user_id));
 			}
+		g_free(mm_user->user_id);
+		g_free(mm_user->room_id);
 		g_free(mm_user);
 		}
 	}

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -972,8 +972,7 @@ mm_add_channels_to_blist(MattermostAccount *ma, JsonNode *node, gpointer user_da
 	guint i, len = json_array_get_length(channels);
 	PurpleGroup *default_group = mm_get_or_create_default_group();
 	GList *ids = NULL;
-    
-			
+    			
 	for (i = 0; i < len; i++) {
 		JsonObject *channel = json_array_get_object_element(channels, i);
 		const gchar *id = json_object_get_string_member(channel, "id");
@@ -993,9 +992,9 @@ mm_add_channels_to_blist(MattermostAccount *ma, JsonNode *node, gpointer user_da
 					user_id = buddy_names[0];
 				}
 				if (user_id != NULL) {
-                    MattermostUser *mm_user = g_new0(MattermostUser,1);
-                    mm_user->room_id=g_strdup(id);
-                    mm_user->user_id=g_strdup(user_id);
+					MattermostUser *mm_user = g_new0(MattermostUser,1);
+					mm_user->room_id=g_strdup(id);
+					mm_user->user_id=g_strdup(user_id);
 
 					username = g_hash_table_lookup(ma->ids_to_usernames, user_id);
 					if (username != NULL) {


### PR DESCRIPTION
Just few questions/comments about this:

1) mm_add_channels_to_blist could be probably simplified  after merging this ? 

2) should mm_get_users_by_ids also populate  ma->one_to_ones/ma->one_to_ones_rev ?

2)  buddies handling - I believe that this should be integrated with server actions:
     add buddy -> should add buddy locally and a direct channel on server
     remove buddy -> should remove buddy locally and remove direct channel on server 
     (and then local buddy list possibly should be re-synced from server and changes applied 
      locally ? in case user uses other clients in parallel)

Your opinion ?

Cheers
Jarek