### PR TITLE
Email Buddy action

### DIFF
--- a/libmattermost.c
+++ b/libmattermost.c
@@ -952,16 +952,8 @@ mm_send_email_cb(PurpleBuddy *buddy)
 	const gchar *email = purple_blist_node_get_string(bnode, "email");
 	const gchar *first_name = purple_blist_node_get_string(bnode, "first_name");
 	const gchar *last_name = purple_blist_node_get_string(bnode, "last_name");
-	GString *full_email = g_string_new(NULL);
+	GString *full_email = g_string_new("mailto:");
 	
-	g_string_append_printf(full_email, "%s %s",	
-#ifdef _WIN32
-	"cmd /c start",
-#else
-	"xdg-open",
-#endif
-	"mailto:\"");
-
 	if (first_name) {
 		g_string_append_printf(full_email, "%s ", first_name);
 	}
@@ -969,15 +961,11 @@ mm_send_email_cb(PurpleBuddy *buddy)
 		g_string_append_printf(full_email, "%s ", last_name);
 	}
 
-	g_string_append_printf(full_email, "<%s>\"", email);
+	g_string_append_printf(full_email, "<%s>", email);
 	
-	gchar *cmd_line=g_string_free(full_email, FALSE);
-
-//  ... it needs full path to xdg-open / cmd ...
-//	purple_notify_uri(purple_account_get_connection(purple_buddy_get_account(buddy)), cmd_line);
-
-	g_spawn_command_line_async(cmd_line, NULL);
-	g_free(cmd_line);
+	gchar *uri = g_string_free(full_email, FALSE);
+	purple_notify_uri(purple_account_get_connection(purple_buddy_get_account(buddy)), uri);
+	g_free(uri);
 }
 
 static GList *

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -4231,7 +4231,7 @@ mm_protocol_client_iface_init(PurpleProtocolClientIface *prpl_info)
 	prpl_info->get_actions = mm_actions;
 	prpl_info->get_account_text_table = mm_get_account_text_table;
 	prpl_info->blist_node_menu = mm_blist_node_menu;
-  prpl_info->tooltip_text = mm_tooltip_text;
+	prpl_info->tooltip_text = mm_tooltip_text;
 
 }
 

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -945,6 +945,56 @@ mm_fetch_url(MattermostAccount *ma, const gchar *url, const gchar *postdata, Mat
 	g_free(cookies);
 }
 
+static void
+mm_send_email_cb(PurpleBuddy *buddy)
+{
+	const gchar *email = purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy),"email");
+	const gchar *first_name = purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy),"first_name");
+	const gchar *last_name = purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy),"last_name");
+	gchar *full_email = g_strdup("\"");
+	
+	if (first_name) {
+		full_email = g_strconcat(full_email,first_name," ",NULL);
+	}
+	if (last_name) {
+		full_email = g_strconcat(full_email,last_name," ",NULL);
+	}
+	full_email = g_strconcat(full_email,"<",email,">",NULL);
+	full_email = g_strconcat(full_email,"\"",NULL);
+
+	gchar *cmd_line = g_strdup_printf(
+#ifdef _WIN32
+		"cmd /c start"
+#else
+		"xdg-open"
+#endif
+		" mailto:%s", full_email);
+		
+	g_spawn_command_line_async(cmd_line, NULL);
+	g_free(full_email);
+	g_free(cmd_line);
+}
+
+static GList *
+mm_buddy_menu(PurpleBuddy *buddy)
+{
+	GList *menu = NULL;
+	if (purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy),"email")) {
+		PurpleMenuAction *action = purple_menu_action_new(_("Email Buddy"),PURPLE_CALLBACK(mm_send_email_cb),NULL, NULL);
+		menu = g_list_append(menu, action);
+	}
+	return menu;
+}
+
+static GList *
+mm_blist_node_menu(PurpleBlistNode *node)
+{
+	if(PURPLE_BLIST_NODE_IS_BUDDY(node)) {
+		return mm_buddy_menu((PurpleBuddy *) node);
+	}
+	return NULL;
+}
+
 static const gchar *
 mm_get_first_team_id(MattermostAccount *ma)
 {
@@ -3994,6 +4044,7 @@ plugin_init(PurplePlugin *plugin)
 	prpl_info->chat_send = mm_chat_send;
 	prpl_info->set_chat_topic = mm_chat_set_topic;
 	prpl_info->add_buddy = mm_add_buddy_no_message;
+	prpl_info->blist_node_menu = mm_blist_node_menu;
 	prpl_info->get_info = mm_get_info;
 	
 	prpl_info->roomlist_get_list = mm_roomlist_get_list;
@@ -4111,6 +4162,7 @@ mm_protocol_client_iface_init(PurpleProtocolClientIface *prpl_info)
 {
 	prpl_info->get_actions = mm_actions;
 	prpl_info->get_account_text_table = mm_get_account_text_table;
+	prpl_info->blist_node_menu = mm_blist_node_menu;
 }
 
 static void 


### PR DESCRIPTION
Adds simple 'Email Buddy' context action - on linux requires xdg-open, should work on windows too (but I have not checked: just seen similar code in use somewhere)