### PR TITLE
channel list / buddy list synchronization with MM server

### DIFF
--- a/libmattermost.c
+++ b/libmattermost.c
@@ -948,7 +948,6 @@ mm_fetch_url(MattermostAccount *ma, const gchar *url, const gchar *postdata, Mat
 static void
 mm_send_email_cb(PurpleBuddy *buddy)
 {
-<<<<<<< HEAD
 	PurpleBlistNode *bnode = PURPLE_BLIST_NODE(buddy);
 	const gchar *email = purple_blist_node_get_string(bnode, "email");
 	const gchar *first_name = purple_blist_node_get_string(bnode, "first_name");
@@ -967,32 +966,6 @@ mm_send_email_cb(PurpleBuddy *buddy)
 	gchar *uri = g_string_free(full_email, FALSE);
 	purple_notify_uri(purple_account_get_connection(purple_buddy_get_account(buddy)), uri);
 	g_free(uri);
-=======
-	const gchar *email = purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy),"email");
-	const gchar *first_name = purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy),"first_name");
-	const gchar *last_name = purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy),"last_name");
-	gchar *full_email = g_strdup("\"");
-	
-	if (first_name) {
-		full_email = g_strconcat(full_email,first_name," ",NULL);
-	}
-	if (last_name) {
-		full_email = g_strconcat(full_email,last_name," ",NULL);
-	}
-	full_email = g_strconcat(full_email,"<",email,">",NULL);
-	full_email = g_strconcat(full_email,"\"",NULL);
-
-	gchar *cmd_line = g_strdup_printf(
-#ifdef _WIN32
-		"cmd /c start"
-#else
-		"xdg-open"
-#endif
-		" mailto:%s", full_email);
-		
-	g_spawn_command_line_async(cmd_line, NULL);
-	g_free(full_email);
-	g_free(cmd_line);
 }
 
 static GList *

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -1516,31 +1516,30 @@ mm_me_response(MattermostAccount *ma, JsonNode *node, gpointer user_data)
 {
 	JsonObject *response;
 
-        if (node == NULL) {
+    if (node == NULL) {
 		purple_connection_error(ma->pc, PURPLE_CONNECTION_ERROR_AUTHENTICATION_FAILED, "Invalid or expired Gitlab cookie");
 		return;
 	}
 
-        response = json_node_get_object(node);
+	response = json_node_get_object(node);
 
-        if (json_object_get_int_member(response, "status_code") >= 400) {
+    if (json_object_get_int_member(response, "status_code") >= 400) {
 		purple_connection_error(ma->pc, PURPLE_CONNECTION_ERROR_AUTHENTICATION_FAILED, g_strconcat(json_object_get_string_member(response, "message"),"(Invalid or expired Gitlab cookie)",NULL));
-	        return;
-        }
+		return;
+	}
 
-        g_free(ma->self_user_id);
+	g_free(ma->self_user_id);
 	ma->self_user_id = g_strdup(json_object_get_string_member(response, "id"));
 	g_free(ma->self_username);
 	ma->self_username = g_strdup(json_object_get_string_member(response, "username"));
-        
+
 	if (!ma->self_user_id || !ma->self_username) {
 		purple_connection_error(ma->pc, PURPLE_CONNECTION_ERROR_AUTHENTICATION_FAILED, "User ID/Name not received from server");
 		return;
 	}
 	
-        mm_set_me(ma);
-		mm_get_teams(ma);
-
+	mm_set_me(ma);
+	mm_get_teams(ma);
 }
 
 static void
@@ -3927,7 +3926,7 @@ mm_remove_buddy(PurpleConnection *pc, PurpleBuddy *buddy, PurpleGroup *group)
 	pref->user_id = g_strdup(ma->self_user_id);
 	pref->category = g_strdup("direct_channel_show");
 	pref->name = g_strdup(purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy), "user_id"));
-	pref->value = "false";
+	pref->value = g_strdup("false");
 	mm_save_user_pref(ma, pref);
    	// free pref in callback
 }

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -455,7 +455,7 @@ mm_markdown_to_html(const gchar *markdown)
 			last_part = markdown_version_split[i++];
 		} while (markdown_version_split[i] != NULL);
 		
-		if (!purple_strequal(last_part, "DEBUG")&&0) {
+		if (!purple_strequal(last_part, "DEBUG")) {
 			markdown_version_safe = TRUE;
 		} else {
 			gint major, minor, micro;

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -3896,7 +3896,7 @@ mm_got_avatar(MattermostAccount *ma, JsonNode *node, gpointer user_data)
 {
 	if (node != NULL) {
 		JsonObject *response = json_node_get_object(node);
-		PurpleBuddy *buddy = user_data;
+		const gchar *buddy_name = user_data;
 		const gchar *response_str;
 		gsize response_len;
 		gpointer response_dup;
@@ -3904,8 +3904,10 @@ mm_got_avatar(MattermostAccount *ma, JsonNode *node, gpointer user_data)
 		response_str = g_dataset_get_data(node, "raw_body");
 		response_len = json_object_get_int_member(response, "len");
 		response_dup = g_memdup(response_str, response_len);
-		
-		purple_buddy_icons_set_for_user(ma->account, purple_buddy_get_name(buddy), response_dup, response_len, NULL);
+
+		if(purple_find_buddy(ma->account, buddy_name)) {
+			purple_buddy_icons_set_for_user(ma->account, buddy_name, response_dup, response_len, NULL);
+		}
 	}
 }
 
@@ -3914,7 +3916,8 @@ mm_get_avatar(MattermostAccount *ma, PurpleBuddy *buddy)
 {
 	//avatar at https://{server}/api/v3/users/{username}/image
 	gchar *url = mm_build_url(ma, "/api/v3/users/%s/image", purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy), "user_id"));
-	mm_fetch_url(ma, url, NULL, mm_got_avatar, buddy);
+	const gchar *buddy_name = purple_buddy_get_name(buddy);
+	mm_fetch_url(ma, url, NULL, mm_got_avatar, (gpointer) buddy_name);
 	g_free(url);
 }
 


### PR DESCRIPTION
Keeps purple buddies and channels in sync with MM server / other MM clients running in parallel. 

I guess that invoking mm_add_channels_to_blist() periodically would be useful ? - for now this synchronization happens only on startup ?

