### PR TITLE
Channel grouping / channel operations 

### DIFF
--- a/libmattermost.c
+++ b/libmattermost.c
@@ -948,7 +948,6 @@ mm_fetch_url(MattermostAccount *ma, const gchar *url, const gchar *postdata, Mat
 static void
 mm_send_email_cb(PurpleBuddy *buddy)
 {
-<<<<<<< HEAD
 	PurpleBlistNode *bnode = PURPLE_BLIST_NODE(buddy);
 	const gchar *email = purple_blist_node_get_string(bnode, "email");
 	const gchar *first_name = purple_blist_node_get_string(bnode, "first_name");
@@ -967,32 +966,6 @@ mm_send_email_cb(PurpleBuddy *buddy)
 	gchar *uri = g_string_free(full_email, FALSE);
 	purple_notify_uri(purple_account_get_connection(purple_buddy_get_account(buddy)), uri);
 	g_free(uri);
-=======
-	const gchar *email = purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy),"email");
-	const gchar *first_name = purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy),"first_name");
-	const gchar *last_name = purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy),"last_name");
-	gchar *full_email = g_strdup("\"");
-	
-	if (first_name) {
-		full_email = g_strconcat(full_email,first_name," ",NULL);
-	}
-	if (last_name) {
-		full_email = g_strconcat(full_email,last_name," ",NULL);
-	}
-	full_email = g_strconcat(full_email,"<",email,">",NULL);
-	full_email = g_strconcat(full_email,"\"",NULL);
-
-	gchar *cmd_line = g_strdup_printf(
-#ifdef _WIN32
-		"cmd /c start"
-#else
-		"xdg-open"
-#endif
-		" mailto:%s", full_email);
-		
-	g_spawn_command_line_async(cmd_line, NULL);
-	g_free(full_email);
-	g_free(cmd_line);
 }
 
 static GList *

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -430,7 +430,8 @@ mm_markdown_to_html(const gchar *markdown)
 			last_part = markdown_version_split[i++];
 		} while (markdown_version_split[i] != NULL);
 		
-		if (!purple_strequal(last_part, "DEBUG")) {
+		if (!purple_strequal(last_part, "DEBUG") &&
+			purple_strequal(last_part, "2.1.8 DEBUG DL=DISCOUNT FENCED-CODE")) { // Fedora 24/25/26 and EPEL 7 libmarkdown
 			markdown_version_safe = TRUE;
 		} else {
 			gint major, minor, micro;

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -470,8 +470,7 @@ mm_markdown_to_html(const gchar *markdown)
 			last_part = markdown_version_split[i++];
 		} while (markdown_version_split[i] != NULL);
 		
-		if (!purple_strequal(last_part, "DEBUG") &&
-			purple_strequal(last_part, "2.1.8 DEBUG DL=DISCOUNT FENCED-CODE")) { // Fedora 24/25/26 and EPEL 7 libmarkdown
+		if (!purple_strequal(last_part, "DEBUG")) {
 			markdown_version_safe = TRUE;
 		} else {
 			gint major, minor, micro;


### PR DESCRIPTION
What it does:

- adds chat/buddy grouping which follows MM clients (Open/Private/Direct) (~/.purple/blist.xml needs to be removed to see the effect)

- moves buddy/chat create/delete/update operations to separate functions
 (parts to be implemented, delete/update functions not used yet)

The idea is to get this called from UI (Add/Remove/Edit Chat) .. but I'm little bit stuck here - thought that purple_blist_set_ui_ops() will allow that but somehow it has no effect .. any idea how this can be achieved with libpurple ?

@EionRobb : your opinion / comments ?

Thanks

Jarek




