### PR TITLE
Add MM slash command pass-through and ephemeral response handling

### DIFF
--- a/libmattermost.c
+++ b/libmattermost.c
@@ -948,7 +948,6 @@ mm_fetch_url(MattermostAccount *ma, const gchar *url, const gchar *postdata, Mat
 static void
 mm_send_email_cb(PurpleBuddy *buddy)
 {
-<<<<<<< HEAD
 	PurpleBlistNode *bnode = PURPLE_BLIST_NODE(buddy);
 	const gchar *email = purple_blist_node_get_string(bnode, "email");
 	const gchar *first_name = purple_blist_node_get_string(bnode, "first_name");
@@ -967,32 +966,6 @@ mm_send_email_cb(PurpleBuddy *buddy)
 	gchar *uri = g_string_free(full_email, FALSE);
 	purple_notify_uri(purple_account_get_connection(purple_buddy_get_account(buddy)), uri);
 	g_free(uri);
-=======
-	const gchar *email = purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy),"email");
-	const gchar *first_name = purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy),"first_name");
-	const gchar *last_name = purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy),"last_name");
-	gchar *full_email = g_strdup("\"");
-	
-	if (first_name) {
-		full_email = g_strconcat(full_email,first_name," ",NULL);
-	}
-	if (last_name) {
-		full_email = g_strconcat(full_email,last_name," ",NULL);
-	}
-	full_email = g_strconcat(full_email,"<",email,">",NULL);
-	full_email = g_strconcat(full_email,"\"",NULL);
-
-	gchar *cmd_line = g_strdup_printf(
-#ifdef _WIN32
-		"cmd /c start"
-#else
-		"xdg-open"
-#endif
-		" mailto:%s", full_email);
-		
-	g_spawn_command_line_async(cmd_line, NULL);
-	g_free(full_email);
-	g_free(cmd_line);
 }
 
 static GList *

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -430,7 +430,8 @@ mm_markdown_to_html(const gchar *markdown)
 			last_part = markdown_version_split[i++];
 		} while (markdown_version_split[i] != NULL);
 		
-		if (!purple_strequal(last_part, "DEBUG")) {
+		if (!purple_strequal(last_part, "DEBUG") &&
+			purple_strequal(last_part, "2.1.8 DEBUG DL=DISCOUNT FENCED-CODE")) { // Fedora 24/25/26 and EPEL 7 libmarkdown
 			markdown_version_safe = TRUE;
 		} else {
 			gint major, minor, micro;

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -455,8 +455,7 @@ mm_markdown_to_html(const gchar *markdown)
 			last_part = markdown_version_split[i++];
 		} while (markdown_version_split[i] != NULL);
 		
-		if (!purple_strequal(last_part, "DEBUG") &&
-			purple_strequal(last_part, "2.1.8 DEBUG DL=DISCOUNT FENCED-CODE")) { // Fedora 24/25/26 and EPEL 7 libmarkdown
+		if (!purple_strequal(last_part, "DEBUG")) {
 			markdown_version_safe = TRUE;
 		} else {
 			gint major, minor, micro;
@@ -1872,7 +1871,7 @@ mm_process_msg(MattermostAccount *ma, JsonNode *element_node)
 		}
 	}
 	
-	if (purple_strequal(event, "posted") || purple_strequal(event, "post_edited")) {
+	if (purple_strequal(event, "posted") || purple_strequal(event, "post_edited") || purple_strequal(event, "ephemeral_message")) {
 		gint64 last_message_timestamp;
 		JsonParser *post_parser = json_parser_new();
 		const gchar *post_str = json_object_get_string_member(data, "post");
@@ -4168,7 +4167,13 @@ mm_slash_command(PurpleConversation *conv, const gchar *cmd, gchar **args, gchar
 	}
 	
 	params_str = g_strjoinv(" ", args);
-	original_msg = g_strconcat("/", cmd, " ", params_str, NULL);
+
+	if (purple_strequal(cmd,"cmd")) {
+		original_msg = g_strconcat("/", params_str, NULL);
+	} else {
+		original_msg = g_strconcat("/", cmd, " ", params_str, NULL);
+	}
+
 	g_free(params_str);
 	
 	data = json_object_new();
@@ -4252,6 +4257,11 @@ plugin_load(PurplePlugin *plugin, GError **error)
 						PURPLE_CMD_FLAG_PROTOCOL_ONLY | PURPLE_CMD_FLAG_ALLOW_WRONG_ARGS,
 						MATTERMOST_PLUGIN_ID, mm_slash_command,
 						_("shrug message:  Post a message as yourelf followed by 'shrug'"), NULL);
+
+	purple_cmd_register("cmd", "s", PURPLE_CMD_P_PLUGIN, PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_IM |
+						PURPLE_CMD_FLAG_PROTOCOL_ONLY | PURPLE_CMD_FLAG_ALLOW_WRONG_ARGS,
+						MATTERMOST_PLUGIN_ID, mm_slash_command,
+						_("cmd <command>:  Pass slash command to Mattermost server / BOT"), NULL);
 	
 	return TRUE;
 }


### PR DESCRIPTION
example (even if that one does not make too much sense ;-)):
```/cmd shortcuts```

this PR allows 'chatting' with BOTs, and makes plugin not discard ephemeral msg type. 