### PR TITLE
buddy list sync with MM (cont'd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Connects libpurple-based instant messaging clients (such as Pidgin, Finch, Adium
 - Display of messages sent while Pidgin was offline. 
 - Mark messages edited by a Mattermost user as "Edited:"
 - If Mattermost [enables public file links](https://docs.mattermost.com/administration/config-settings.html#enable-public-file-links) (off by default) file sharing links can be displayed in Pidgin. 
+- Display of emojis (install [Pidgin EmojiOne smileys theme](https://github.com/niclashoyer/pidgin-emojione))
 
 **Group Discussions**
 

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -1356,6 +1356,11 @@ static void
 mm_get_channel_by_id(MattermostAccount *ma, const gchar *id)
 {
 	gchar *url;
+
+	if (id == NULL) {
+		return;
+	}
+
 	const gchar *team_id = mm_get_first_team_id(ma);
 
 	url = mm_build_url(ma, "/api/v3/teams/%s/channels/%s/",team_id,id); 
@@ -2021,7 +2026,7 @@ mm_process_msg(MattermostAccount *ma, JsonNode *element_node)
 			const gchar *user_id =  mm_data_or_broadcast_string("user_id");
 					
 			//type system_join_channel			
-			if (!g_hash_table_lookup(ma->group_chats, channel_id) && purple_strequal(ma->self_user_id, user_id)) {
+			if (channel_id && !g_hash_table_lookup(ma->group_chats, channel_id) && purple_strequal(ma->self_user_id, user_id)) {
 				mm_get_channel_by_id(ma, channel_id);
 				//TODO: open conversation window (in mm_get_channel_by_id_response()) ?
 			}

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -117,8 +117,7 @@ json_named_array_from_string(const gchar *name, const gchar *str)
 	gchar *data = g_strconcat("{\"", name , "\":", str, "}", NULL);
 
 	if (json_parser_load_from_data(parser, data, -1, NULL)) {
-		array = json_object_get_array_member(json_node_get_object(json_parser_get_root(parser)), name); 
-
+		array = json_object_get_array_member(json_node_get_object(json_parser_get_root(parser)), name);
 	}
 
 	g_free(data);
@@ -1068,7 +1067,6 @@ mm_clean_channels(MattermostAccount *ma, GList *ids)
 				pref->value = g_strdup("false");
 				group_prefs = g_list_prepend(group_prefs, pref);
 			}
-
 		} else if (PURPLE_IS_BUDDY(node)) {
 			PurpleBuddy *buddy = PURPLE_BUDDY(node);
 			if (purple_buddy_get_account(buddy) != ma->account) {
@@ -1346,8 +1344,6 @@ mm_get_channel_by_id(MattermostAccount *ma, const gchar *id)
 	} \
 }
 
-
-
 static void
 mm_get_users_by_ids_response(MattermostAccount *ma, JsonNode *node, gpointer user_data)
 {
@@ -1398,8 +1394,7 @@ mm_get_users_by_ids_response(MattermostAccount *ma, JsonNode *node, gpointer use
 
 static void
 mm_get_users_by_ids(MattermostAccount *ma, GList *ids)
-{
-	
+{	
 	GList *i;
 	gchar *url, *postdata;
 	MattermostUser *mm_user;
@@ -1549,7 +1544,6 @@ mm_compare_prefs_int(gconstpointer a, gconstpointer b)
 static void
 mm_list_user_prefs_channel_show_response(MattermostAccount *ma, JsonNode *node, gpointer user_data)
 {
-
 	if (json_node_get_node_type(node) == JSON_NODE_OBJECT) {
 		JsonObject *response = json_node_get_object(node);
 		if (json_object_get_int_member(response, "status_code") >= 400) {
@@ -1557,7 +1551,6 @@ mm_list_user_prefs_channel_show_response(MattermostAccount *ma, JsonNode *node, 
 			return;
 		}
 	} else {
-
         JsonArray *arr = json_node_get_array(node);
         GList *users = json_array_get_elements(arr);
         GList *prefs = user_data;

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -2098,12 +2098,12 @@ mm_process_msg(MattermostAccount *ma, JsonNode *element_node)
 			}
 			if (purple_strequal(json_object_get_string_member(object, "category"), "group_channel_show")) {
 				if (purple_strequal(json_object_get_string_member(object, "value"), "false")) {
-					if (g_hash_table_contains(ma->group_chats_rev, id)) {
-						const gchar *chat_name = g_hash_table_lookup(ma->group_chats_rev, id);
+					if (g_hash_table_contains(ma->group_chats, id)) {
+						const gchar *chat_name = g_hash_table_lookup(ma->group_chats, id);
 						PurpleChat *chat = purple_blist_find_chat(ma->account, chat_name);
 						if (chat) {
-							g_hash_table_remove(ma->group_chats_rev, id);
-							g_hash_table_remove(ma->group_chats, chat_name);
+							g_hash_table_remove(ma->group_chats, id);
+							g_hash_table_remove(ma->group_chats_rev, chat_name);
 							purple_blist_remove_chat(chat);
 						}
 					}

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -1871,7 +1871,7 @@ mm_process_msg(MattermostAccount *ma, JsonNode *element_node)
 		}
 	}
 	
-	if (purple_strequal(event, "posted") || purple_strequal(event, "post_edited")) {
+	if (purple_strequal(event, "posted") || purple_strequal(event, "post_edited") || purple_strequal(event, "ephemeral_message")) {
 		gint64 last_message_timestamp;
 		JsonParser *post_parser = json_parser_new();
 		const gchar *post_str = json_object_get_string_member(data, "post");
@@ -4167,7 +4167,13 @@ mm_slash_command(PurpleConversation *conv, const gchar *cmd, gchar **args, gchar
 	}
 	
 	params_str = g_strjoinv(" ", args);
-	original_msg = g_strconcat("/", cmd, " ", params_str, NULL);
+
+	if (purple_strequal(cmd,"cmd")) {
+		original_msg = g_strconcat("/", params_str, NULL);
+	} else {
+		original_msg = g_strconcat("/", cmd, " ", params_str, NULL);
+	}
+
 	g_free(params_str);
 	
 	data = json_object_new();
@@ -4251,6 +4257,11 @@ plugin_load(PurplePlugin *plugin, GError **error)
 						PURPLE_CMD_FLAG_PROTOCOL_ONLY | PURPLE_CMD_FLAG_ALLOW_WRONG_ARGS,
 						MATTERMOST_PLUGIN_ID, mm_slash_command,
 						_("shrug message:  Post a message as yourelf followed by 'shrug'"), NULL);
+
+	purple_cmd_register("cmd", "s", PURPLE_CMD_P_PLUGIN, PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_IM |
+						PURPLE_CMD_FLAG_PROTOCOL_ONLY | PURPLE_CMD_FLAG_ALLOW_WRONG_ARGS,
+						MATTERMOST_PLUGIN_ID, mm_slash_command,
+						_("cmd <command>:  Pass slash command to Mattermost server / BOT"), NULL);
 	
 	return TRUE;
 }

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -1206,6 +1206,8 @@ mm_add_channels_to_blist(MattermostAccount *ma, JsonNode *node, gpointer user_da
 	mm_get_users_by_ids(ma, ids);
 	//g_list_free(ids); in callback !
 	mm_clean_channels(ma, seen_ids);
+	//TODO: problem: get_users_by_ids() callback may finish after mm_clean_channels() 
+	//      'hidden' buddies (direct_channel_show = false) will NOT be removed from blist
 	g_list_free_full(seen_ids,g_free);	
 	g_free(team_id);
 }

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -440,43 +440,43 @@ mm_markdown_to_html(const gchar *markdown)
 	int markdown_len;
 	int flags = MKD_NOPANTS | MKD_NODIVQUOTE | MKD_NODLIST;
 	static gboolean markdown_version_checked = FALSE;
-	static gboolean markdown_version_safe = FALSE;
+	static gboolean markdown_version_safe = TRUE;
 	
 	if (markdown == NULL) {
 		return NULL;
 	}
 	
 	if (!markdown_version_checked) {
-		gchar **markdown_version_split = g_strsplit_set(	markdown_version, ". ", -1);
-		gchar *last_part;
-		guint i = 0;
+		gchar **markdown_version_split = g_strsplit_set(markdown_version, ". ", -1);
+		gint major, minor, micro;
 
-		do {
-			last_part = markdown_version_split[i++];
-		} while (markdown_version_split[i] != NULL);
-		
-		if (!purple_strequal(last_part, "DEBUG")) {
-			markdown_version_safe = TRUE;
-		} else {
-			gint major, minor, micro;
-			major = atoi(markdown_version_split[0]);
-			if (major > 2) {
-				markdown_version_safe = TRUE;
-			} else if (major == 2) {
-				minor = atoi(markdown_version_split[1]);
-				if (minor > 2) {
-					markdown_version_safe = TRUE;
-				} else if (minor == 2) {
-					micro = atoi(markdown_version_split[2]);
-					if (micro > 2) {
-						markdown_version_safe = TRUE;
-					}
+		major = atoi(markdown_version_split[0]);
+		if (major > 2) {
+			markdown_version_checked = TRUE;
+		} else if (major == 2) {
+			minor = atoi(markdown_version_split[1]);
+			if (minor > 2) {
+				markdown_version_checked = TRUE;
+			} else if (minor == 2) {
+				micro = atoi(markdown_version_split[2]);
+				if (micro > 2) {
+					markdown_version_checked = TRUE;
 				}
 			}
 		}
 		
+		if (!markdown_version_checked) {
+			guint i;
+			for(i = 0; markdown_version_split[i]; i++) {
+				if (purple_strequal(markdown_version_split[i], "DEBUG")) {
+					markdown_version_safe = FALSE;
+					break;
+				}
+			}
+			markdown_version_checked = TRUE;
+		}
+		
 		g_strfreev(markdown_version_split);
-		markdown_version_checked = TRUE;
 	}
 	
 	if (markdown_str != NULL) {

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -3906,7 +3906,7 @@ mm_got_avatar(MattermostAccount *ma, JsonNode *node, gpointer user_data)
 		response_len = json_object_get_int_member(response, "len");
 		response_dup = g_memdup(response_str, response_len);
 
-		if(purple_find_buddy(ma->account, buddy_name)) {
+		if(purple_blist_find_buddy(ma->account, buddy_name)) {
 			purple_buddy_icons_set_for_user(ma->account, buddy_name, response_dup, response_len, NULL);
 		}
 	}

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -3668,6 +3668,7 @@ mm_got_add_buddy_user(MattermostAccount *ma, JsonNode *node, gpointer user_data)
 	if (json_object_has_member(user, "status_code")) {
 		// bad user, delete
 		purple_blist_remove_buddy(buddy);
+		purple_notify_error(ma->pc, _("Add Buddy Error"), _("There was an error searching for the user"), json_object_get_string_member(user, "message"), purple_request_cpar_from_connection(ma->pc));
 		return;
 	}
 	

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -1178,13 +1178,12 @@ mm_add_channels_to_blist(MattermostAccount *ma, JsonNode *node, gpointer user_da
 				g_hash_table_replace(ma->group_chats_rev, g_strdup(name), g_strdup(id));
 				
 				purple_blist_node_set_bool(PURPLE_BLIST_NODE(chat), "gtk-persistent", TRUE);
-<<<<<<< HEAD
 		
 				if (room_type && *room_type == MATTERMOST_CHANNEL_GROUP) {
 					MattermostUser *mm_user = g_new0(MattermostUser,1);
 					mm_user->user_id=g_strdup(id);
 					ids = g_list_append(ids,mm_user);
-=======
+				}
 
 				if (autojoin) {
 					PurpleChatConversation *chatconv = NULL;
@@ -1199,7 +1198,6 @@ mm_add_channels_to_blist(MattermostAccount *ma, JsonNode *node, gpointer user_da
 
 					purple_conversation_present(PURPLE_CONVERSATION(chatconv));
 					mm_join_room(ma, g_strdup(team_id), g_strdup(id));
->>>>>>> master
 				}
 			}
 		}

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -88,6 +88,25 @@ json_object_to_string(JsonObject *obj)
 	return str;
 }
 
+static gchar *
+json_array_to_string(JsonArray *array)
+{
+	JsonNode *node;
+	gchar *str;
+	JsonGenerator *generator;
+
+	node = json_node_new(JSON_NODE_OBJECT);
+	json_node_init_array(node, array);
+
+	// a json string ...
+	generator = json_generator_new();
+	json_generator_set_root(generator, node);
+	str = json_generator_to_data(generator, NULL);
+	g_object_unref(generator);
+	json_node_free(node);
+	
+	return str;
+}
 
 #include <purple.h>
 #if PURPLE_VERSION_CHECK(3, 0, 0)
@@ -368,6 +387,12 @@ typedef struct {
 //	gchar *username;
 } MattermostUser;
 
+typedef struct {
+	gchar *user_id;
+	gchar *category;
+	gchar *name;
+	gchar *value;
+} MattermostUserPref;
 
 //#include <mkdio.h>
 extern char markdown_version[];
@@ -999,6 +1024,43 @@ mm_get_first_team_id(MattermostAccount *ma)
 	return first_team_id;
 }
 
+static void mm_list_user_prefs(MattermostAccount *ma, const gchar *category, GList *prefs);
+
+// we clean channels by room_id: name/alias may change on MM server.
+static void
+mm_clean_channels(MattermostAccount *ma, GList *ids)
+{
+	PurpleBlistNode *node;
+	GList *prefs = NULL;
+	
+	for (node = purple_blist_get_root(); node != NULL; node = purple_blist_node_next(node, TRUE)) {
+		if (PURPLE_IS_CHAT(node)) {
+			PurpleChat *chat = PURPLE_CHAT(node);
+			if (purple_chat_get_account(chat) != ma->account) {
+				continue;
+			}
+			if (g_list_find_custom(ids, purple_blist_node_get_string(node, "room_id"), (GCompareFunc)g_strcmp0) == NULL) {				
+				purple_blist_remove_chat(chat);
+			}	
+		} else if (PURPLE_IS_BUDDY(node)) {
+			PurpleBuddy *buddy = PURPLE_BUDDY(node);
+			if (purple_buddy_get_account(buddy) != ma->account) {
+				continue;
+			}
+			MattermostUserPref *pref = g_new0(MattermostUserPref,1);
+			pref->user_id = g_strdup(ma->self_user_id);
+			pref->category = g_strdup("direct_channel_show"); 
+			pref->name = g_strdup(purple_blist_node_get_string(node, "user_id"));
+			pref->value = g_strdup("false");
+			prefs = g_list_append(prefs, pref);
+		}
+	}
+
+	mm_list_user_prefs(ma, "direct_channel_show", prefs);
+	// free prefs in callback!
+}
+
+
 PurpleGroup* mm_get_or_create_default_group();
 static void mm_get_history_of_room(MattermostAccount *ma, const gchar *team_id, const gchar *channel_id, gint64 since);
 static void mm_add_buddy(PurpleConnection *pc, PurpleBuddy *buddy, PurpleGroup *group, const char *message);
@@ -1016,12 +1078,17 @@ mm_add_channels_to_blist(MattermostAccount *ma, JsonNode *node, gpointer user_da
 	guint i, len = json_array_get_length(channels);
 	PurpleGroup *default_group = mm_get_or_create_default_group();
 	GList *ids = NULL;
-	
+	GList *seen_ids = NULL;
+
 	for (i = 0; i < len; i++) {
 		JsonObject *channel = json_array_get_object_element(channels, i);
 		const gchar *id = json_object_get_string_member(channel, "id");
 		const gchar *name = json_object_get_string_member(channel, "display_name");
 		const gchar *room_type = json_object_get_string_member(channel, "type");
+
+		if(id && *id) {
+			seen_ids=g_list_prepend(seen_ids,g_strdup(id));
+		}
 		
 		if (room_type && *room_type == MATTERMOST_CHANNEL_DIRECT) {
 			if (!g_hash_table_contains(ma->one_to_ones, id)) {
@@ -1087,6 +1154,8 @@ mm_add_channels_to_blist(MattermostAccount *ma, JsonNode *node, gpointer user_da
 		
 	mm_get_users_by_ids(ma, ids);
 	//g_list_free(ids); in callback !
+	mm_clean_channels(ma, seen_ids);
+	g_list_free_full(seen_ids,g_free);	
 	g_free(team_id);
 }
 
@@ -1322,36 +1391,155 @@ mm_get_teams(MattermostAccount *ma)
 	g_free(url);
 	
 }
+
+static void 
+mm_save_user_pref_response(MattermostAccount *ma, JsonNode *node, gpointer user_data)
+{
+	MattermostUserPref *pref = user_data;
+	g_free(pref);
+	
+	if (json_node_get_node_type(node) == JSON_NODE_OBJECT) {
+		JsonObject *response = json_node_get_object(node);
+		if (json_object_get_int_member(response, "status_code") >= 400) {
+			purple_notify_error(ma->pc, _("Save Preferences Error"), _("There was an error saving user preferences"), json_object_get_string_member(response, "message"), purple_request_cpar_from_connection(ma->pc));
+		return;
+        }
+	}
+}
+
+static void
+mm_save_user_pref(MattermostAccount *ma, MattermostUserPref *pref)
+{
+	JsonArray *data = json_array_new();
+	JsonObject *pref_data = json_object_new();
+	gchar *postdata, *url;
+	
+	json_object_set_string_member(pref_data, "user_id", pref->user_id);
+	json_object_set_string_member(pref_data, "category", pref->category);
+	json_object_set_string_member(pref_data, "name", pref->name);
+	json_object_set_string_member(pref_data, "value", pref->value);
+
+	json_array_add_object_element(data,pref_data);
+	postdata = json_array_to_string(data);
+	
+	if (purple_strequal(pref->category,"direct_channel_show")) {
+		url = mm_build_url(ma, "/api/v3/preferences/save");
+		mm_fetch_url(ma, url, postdata, mm_save_user_pref_response, pref);
+	}
+
+	g_free(postdata);
+	json_array_unref(data);
+}
+
+int
+mm_compare_prefs_int(gconstpointer a, gconstpointer b)
+{
+	const MattermostUserPref *p1 = a;
+	const MattermostUserPref *p2 = b;
+
+	if (!(g_strcmp0(p1->user_id,p2->user_id) &&
+		g_strcmp0(p1->category,p2->category) &&
+		g_strcmp0(p1->name,p2->name) &&
+		g_strcmp0(p1->value,p2->value))) {
+		return 0;
+	} 
+	return -1;
+}
+
+static void
+mm_list_user_prefs_direct_channel_show_response(MattermostAccount *ma, JsonNode *node, gpointer user_data)
+{
+
+	if (json_node_get_node_type(node) == JSON_NODE_OBJECT) {
+		JsonObject *response = json_node_get_object(node);
+		if (json_object_get_int_member(response, "status_code") >= 400) {
+			purple_notify_error(ma->pc, _("Get Preferences Error"), _("There was an error reading user preferences from server"), json_object_get_string_member(response, "message"), purple_request_cpar_from_connection(ma->pc));
+			return;
+		}
+	} else {
+
+        JsonArray *arr = json_node_get_array(node);
+        GList *users = json_array_get_elements(arr);
+        GList *prefs = user_data;
+        GList *i;
+		GList *remove_users = NULL;
+		MattermostUserPref *pref = g_new0(MattermostUserPref,1);
+
+        for (i = users; i != NULL; i = i->next) {
+	
+			JsonNode *usernode = i->data;
+			JsonObject *user = json_node_get_object(usernode);
+
+			pref->user_id = g_strdup(json_object_get_string_member(user, "user_id"));
+			pref->category = g_strdup(json_object_get_string_member(user, "category"));
+			pref->name = g_strdup(json_object_get_string_member(user, "name"));
+			pref->value = g_strdup(json_object_get_string_member(user, "value"));
+			
+			if (g_list_find_custom(prefs, pref, mm_compare_prefs_int)) {
+				PurpleBlistNode *node;
+				for (node = purple_blist_get_root(); node != NULL; node = purple_blist_node_next(node, TRUE)) {
+					if (PURPLE_IS_BUDDY(node)) {
+						PurpleBuddy *buddy = PURPLE_BUDDY(node);
+						if (purple_buddy_get_account(buddy) != ma->account) {
+							continue;
+						}
+						if(purple_strequal(pref->value,"false") && purple_strequal(pref->name, purple_blist_node_get_string(node, "user_id"))) {					
+							remove_users=g_list_prepend(remove_users,buddy);							
+						}
+					}
+				}				
+			}
+		}
+		for (i = remove_users;i != NULL;i=i->next) {
+			purple_blist_remove_buddy(PURPLE_BUDDY(i->data));
+			// BUG??: sometimes segfaults (libpurple 2.10.7 / RHEL7) while removing > 3-4 buddies ??BUG
+		}
+	}
+}
+
+static void
+mm_list_user_prefs(MattermostAccount *ma, const gchar *category, GList *prefs)
+{
+	
+	if (purple_strequal(category,"direct_channel_show")) {
+		gchar *url;
+		url = mm_build_url(ma, "/api/v3/preferences/%s",category);
+		mm_fetch_url(ma, url, NULL, mm_list_user_prefs_direct_channel_show_response, prefs);
+		g_free(url);
+	}
+
+}
+
+
 static void
 mm_me_response(MattermostAccount *ma, JsonNode *node, gpointer user_data)
 {
 	JsonObject *response;
 
-        if (node == NULL) {
+    if (node == NULL) {
 		purple_connection_error(ma->pc, PURPLE_CONNECTION_ERROR_AUTHENTICATION_FAILED, "Invalid or expired Gitlab cookie");
 		return;
 	}
 
-        response = json_node_get_object(node);
+	response = json_node_get_object(node);
 
-        if (json_object_get_int_member(response, "status_code") >= 400) {
+    if (json_object_get_int_member(response, "status_code") >= 400) {
 		purple_connection_error(ma->pc, PURPLE_CONNECTION_ERROR_AUTHENTICATION_FAILED, g_strconcat(json_object_get_string_member(response, "message"),"(Invalid or expired Gitlab cookie)",NULL));
-	        return;
-        }
+		return;
+	}
 
-        g_free(ma->self_user_id);
+	g_free(ma->self_user_id);
 	ma->self_user_id = g_strdup(json_object_get_string_member(response, "id"));
 	g_free(ma->self_username);
 	ma->self_username = g_strdup(json_object_get_string_member(response, "username"));
-        
+
 	if (!ma->self_user_id || !ma->self_username) {
 		purple_connection_error(ma->pc, PURPLE_CONNECTION_ERROR_AUTHENTICATION_FAILED, "User ID/Name not received from server");
 		return;
 	}
 	
-        mm_set_me(ma);
+	mm_set_me(ma);
 	mm_get_teams(ma);
-
 }
 
 static void
@@ -3418,13 +3606,14 @@ const gchar *who, const gchar *message, PurpleMessageFlags flags)
 	if (room_id == NULL) {
 		JsonObject *data;
 		gchar *url, *postdata;
+		const gchar *user_id = g_hash_table_lookup(ma->usernames_to_ids, who);
 #if !PURPLE_VERSION_CHECK(3, 0, 0)
 		PurpleMessage *msg = purple_message_new_outgoing(who, message, flags);
 #endif
 		
 		data = json_object_new();
 		
-		json_object_set_string_member(data, "user_id", g_hash_table_lookup(ma->usernames_to_ids, who));
+		json_object_set_string_member(data, "user_id", user_id);
 		
 		postdata = json_object_to_string(data);
 		url = mm_build_url(ma, "/api/v3/teams/%s/channels/create_direct", team_id);
@@ -3434,6 +3623,15 @@ const gchar *who, const gchar *message, PurpleMessageFlags flags)
 		g_free(postdata);
 		json_object_unref(data);
 		
+		MattermostUserPref *pref = g_new0(MattermostUserPref, 1);
+		pref->user_id = g_strdup(ma->self_user_id);
+		pref->category = g_strdup("direct_channel_show");
+		pref->name = g_strdup(user_id);
+		pref->value = g_strdup("true");
+
+		mm_save_user_pref(ma, pref);
+		// free pref in callback
+
 		return 1;
 	}
 	
@@ -3699,7 +3897,7 @@ mm_got_avatar(MattermostAccount *ma, JsonNode *node, gpointer user_data)
 {
 	if (node != NULL) {
 		JsonObject *response = json_node_get_object(node);
-		PurpleBuddy *buddy = user_data;
+		const gchar *buddy_name = user_data;
 		const gchar *response_str;
 		gsize response_len;
 		gpointer response_dup;
@@ -3707,8 +3905,10 @@ mm_got_avatar(MattermostAccount *ma, JsonNode *node, gpointer user_data)
 		response_str = g_dataset_get_data(node, "raw_body");
 		response_len = json_object_get_int_member(response, "len");
 		response_dup = g_memdup(response_str, response_len);
-		
-		purple_buddy_icons_set_for_user(ma->account, purple_buddy_get_name(buddy), response_dup, response_len, NULL);
+
+		if(purple_find_buddy(ma->account, buddy_name)) {
+			purple_buddy_icons_set_for_user(ma->account, buddy_name, response_dup, response_len, NULL);
+		}
 	}
 }
 
@@ -3716,9 +3916,35 @@ static void
 mm_get_avatar(MattermostAccount *ma, PurpleBuddy *buddy)
 {
 	//avatar at https://{server}/api/v3/users/{username}/image
-	gchar *url = mm_build_url(ma, "/api/v3/users/%s/image", purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy),"user_id"));
-	mm_fetch_url(ma, url, NULL, mm_got_avatar, buddy);
+	gchar *url = mm_build_url(ma, "/api/v3/users/%s/image", purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy), "user_id"));
+	const gchar *buddy_name = g_strdup(purple_buddy_get_name(buddy));
+	mm_fetch_url(ma, url, NULL, mm_got_avatar, (gpointer) buddy_name);
 	g_free(url);
+}
+
+static void
+mm_fake_group_buddy(PurpleConnection *pc, const char *who, const char *old_group, const char *new_group)
+{
+	// Do nothing to stop the remove+add behaviour
+}
+
+static void
+mm_fake_group_rename(PurpleConnection *pc, const char *old_name, PurpleGroup *group, GList *moved_buddies)
+{
+	// Do nothing to stop the remove+add behaviour
+}
+
+static void 
+mm_remove_buddy(PurpleConnection *pc, PurpleBuddy *buddy, PurpleGroup *group)
+{
+	MattermostAccount *ma = purple_connection_get_protocol_data(pc);
+	MattermostUserPref *pref = g_new0(MattermostUserPref,1);
+	pref->user_id = g_strdup(ma->self_user_id);
+	pref->category = g_strdup("direct_channel_show");
+	pref->name = g_strdup(purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy), "user_id"));
+	pref->value = g_strdup("false");
+	mm_save_user_pref(ma, pref);
+   	// free pref in callback
 }
 
 static void
@@ -3749,6 +3975,13 @@ mm_add_buddy(PurpleConnection *pc, PurpleBuddy *buddy, PurpleGroup *group, const
 	purple_blist_node_set_string(PURPLE_BLIST_NODE(buddy), "user_id", user_id);
 	
 	mm_get_avatar(ma,buddy);
+	MattermostUserPref *pref = g_new0(MattermostUserPref,1);
+	pref->user_id = g_strdup(ma->self_user_id);
+	pref->category = g_strdup("direct_channel_show");
+	pref->name = g_strdup(user_id);
+	pref->value = g_strdup("true");
+	mm_save_user_pref(ma,pref);
+	// free pref in callback
 	
 	// Refresh status
 	{
@@ -4099,6 +4332,9 @@ plugin_init(PurplePlugin *plugin)
 	prpl_info->chat_send = mm_chat_send;
 	prpl_info->set_chat_topic = mm_chat_set_topic;
 	prpl_info->add_buddy = mm_add_buddy_no_message;
+	prpl_info->remove_buddy = mm_remove_buddy;
+	prpl_info->group_buddy = mm_fake_group_buddy;
+	prpl_info->rename_group = mm_fake_group_rename;
 	prpl_info->blist_node_menu = mm_blist_node_menu;
 	prpl_info->get_info = mm_get_info;
 	prpl_info->tooltip_text = mm_tooltip_text;
@@ -4209,6 +4445,9 @@ static void
 mm_protocol_server_iface_init(PurpleProtocolServerIface *prpl_info)
 {
 	prpl_info->add_buddy = mm_add_buddy;
+	prpl_info->remove_buddy = mm_remove_buddy;
+	prpl_info->group_buddy = mm_fake_group_buddy;
+	prpl_info->rename_group = mm_fake_group_rename;
 	prpl_info->set_status = mm_set_status;
 	prpl_info->set_idle = mm_set_idle;
 	prpl_info->get_info = mm_get_info;

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -1357,7 +1357,7 @@ mm_get_channel_by_id(MattermostAccount *ma, const gchar *id)
 {
 	gchar *url;
 
-	if (id == NULL) {
+	if (purple_strequal(id,"") || id == NULL) {
 		return;
 	}
 
@@ -2025,15 +2025,17 @@ mm_process_msg(MattermostAccount *ma, JsonNode *element_node)
 			const gchar *channel_id = json_object_get_string_member(post, "channel_id");
 			const gchar *user_id =  mm_data_or_broadcast_string("user_id");
 					
-			//type system_join_channel			
-			if (channel_id && !g_hash_table_lookup(ma->group_chats, channel_id) && purple_strequal(ma->self_user_id, user_id)) {
+			//type system_join_channel, channel_id is ""		
+			if (!purple_strequal(channel_id,"") && !g_hash_table_lookup(ma->group_chats, channel_id) && purple_strequal(ma->self_user_id, user_id)) {
 				mm_get_channel_by_id(ma, channel_id);
 				//TODO: open conversation window (in mm_get_channel_by_id_response()) ?
 			}
 
-			last_message_timestamp = mm_process_room_message(ma, post, data);
+			if (!purple_strequal(channel_id,"")) {
+				last_message_timestamp = mm_process_room_message(ma, post, data);
 			
-			mm_set_room_last_timestamp(ma, channel_id, last_message_timestamp);
+				mm_set_room_last_timestamp(ma, channel_id, last_message_timestamp);
+			}
 		}
 		g_object_unref(post_parser);
 	} else if (purple_strequal(event, "typing")) {		

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -96,7 +96,7 @@ json_array_to_string(JsonArray *array)
 	JsonGenerator *generator;
 
 	node = json_node_new(JSON_NODE_OBJECT);
-	json_node_init_array(node, array);
+	json_node_set_array(node, array);
 
 	// a json string ...
 	generator = json_generator_new();

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -95,7 +95,7 @@ json_array_to_string(JsonArray *array)
 	gchar *str;
 	JsonGenerator *generator;
 
-	node = json_node_new(JSON_NODE_OBJECT);
+	node = json_node_new(JSON_NODE_ARRAY);
 	json_node_set_array(node, array);
 
 	// a json string ...


### PR DESCRIPTION
This PR implements bi-directional channels/buddies synchronization between MM and pidgin.  (its a followup on: https://github.com/EionRobb/purple-mattermost/pull/27)

What is still missing AFAICT: 

- chat delete from pidgin is local, change is not propagated to MM.
- chat creation from pidgin is local, change not propagated to MM.

(still did not figure out how to hook-in Chat menu .. to replace / modify items .. any advice where to look ?)

I'm closing: https://github.com/EionRobb/purple-mattermost/pull/35, I think this one is better for channels/buddies operations... (as for channel grouping by type: after second thought .. I'm not sure this should be handled by the plugin or left to user ...maybe such channel grouping could be added as an optional feature rather (or not at all?) ? .. let me know your opinion.

Thanks !

Jarek   