### PR TITLE
Auto-Join new chats account option

### DIFF
--- a/libmattermost.c
+++ b/libmattermost.c
@@ -1079,6 +1079,7 @@ mm_add_channels_to_blist(MattermostAccount *ma, JsonNode *node, gpointer user_da
 	PurpleGroup *default_group = mm_get_or_create_default_group();
 	GList *ids = NULL;
 	GList *seen_ids = NULL;
+	gboolean autojoin = purple_account_get_bool(ma->account, "use-autojoin", FALSE);
 
 	for (i = 0; i < len; i++) {
 		JsonObject *channel = json_array_get_object_element(channels, i);
@@ -1148,6 +1149,19 @@ mm_add_channels_to_blist(MattermostAccount *ma, JsonNode *node, gpointer user_da
 				g_hash_table_replace(ma->group_chats_rev, g_strdup(name), g_strdup(id));
 				
 				purple_blist_node_set_bool(PURPLE_BLIST_NODE(chat), "gtk-persistent", TRUE);
+
+				if (autojoin) {
+					purple_blist_node_set_bool(PURPLE_BLIST_NODE(chat), "gtk-autojoin", TRUE);
+					//TODO: open conversation window ? (now only on next startup)
+				}
+			} else {
+				if (autojoin) {
+					PurpleChat *chat = purple_blist_find_chat(ma->account, g_hash_table_lookup(ma->group_chats, id));
+					if (chat) {
+						purple_blist_node_set_bool(PURPLE_BLIST_NODE(chat), "gtk-autojoin", TRUE);
+						//TODO: open conversation window ? (now only on next startup)
+					}
+				}
 			}
 		}
 	}
@@ -4062,6 +4076,9 @@ mm_add_account_options(GList *account_options)
 	account_options = g_list_append(account_options, option);
 
 	option = purple_account_option_bool_new(N_("Password is Gitlab cookie"), "use-mmauthtoken", FALSE);
+	account_options = g_list_append(account_options, option);
+
+	option = purple_account_option_bool_new(N_("Auto-Join chats"),"use-autojoin", FALSE);
 	account_options = g_list_append(account_options, option);
 	
 	return account_options;


### PR DESCRIPTION
Adds Auto-Join account option - new channels are automatically opened. off by default.
For now this happens only on startup: but can be added for other cases if you merge this one and https://github.com/EionRobb/purple-mattermost/pull/38