### PR TITLE
commands to set channel header or purpose

### DIFF
--- a/libmattermost.c
+++ b/libmattermost.c
@@ -3425,7 +3425,8 @@ mm_got_users_of_room(MattermostAccount *ma, JsonNode *node, gpointer user_data)
 			const gchar *username = json_object_get_string_member(user, "username");
 			const gchar *roles = json_object_get_string_member(user, "roles");
 
-			if (purple_strequal(ma->self_username, username) && found_myself) {
+			if (!found_myself && purple_strequal(ma->self_username, username)) {
+				found_myself = TRUE;
 				continue;
 			}
 


### PR DESCRIPTION
Now we have a way of displaying both channel header and purpose (https://github.com/EionRobb/purple-mattermost/pull/43) it would be nice to have commands to set these from plugin too.