### PR TITLE
Implements Send File for both IM and CHAT conversations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Not implemented yet:
  
 - Send and receive messages, including weblinks, emoji and images.
 - Display of online/offline/busy/away status. 
+- Send files - using **/sendfile** command in chats, ** Conversation -> Send File ** command in direct conversations.
 - Sending of read notifications so the server understands users is still online. 
 - Display of messages sent while Pidgin was offline. 
 - Mark messages edited by a Mattermost user as "Edited:"

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -318,9 +318,8 @@ mm_make_topic(const gchar *header, const gchar *purpose, const gchar *old_topic)
 }
 
 static void
-mm_send_email_cb(PurpleBuddy *buddy)
+mm_send_email_menu_cb(PurpleBlistNode *bnode)
 {
-	PurpleBlistNode *bnode = PURPLE_BLIST_NODE(buddy);
 	const gchar *email = purple_blist_node_get_string(bnode, "email");
 	const gchar *first_name = purple_blist_node_get_string(bnode, "first_name");
 	const gchar *last_name = purple_blist_node_get_string(bnode, "last_name");
@@ -336,28 +335,44 @@ mm_send_email_cb(PurpleBuddy *buddy)
 	g_string_append_printf(full_email, "<%s>", email);
 	
 	gchar *uri = g_string_free(full_email, FALSE);
-	purple_notify_uri(purple_account_get_connection(purple_buddy_get_account(buddy)), uri);
+	purple_notify_uri(purple_account_get_connection(purple_buddy_get_account(PURPLE_BUDDY(bnode))), uri);
 	g_free(uri);
 }
 
-static GList *
-mm_buddy_menu(PurpleBuddy *buddy)
+static void mm_send_file(PurpleConnection *gc, const char *who, const char *file);
+
+/*
+static void 
+mm_send_file_menu_cb(PurpleBlistNode *bnode)
 {
-	GList *menu = NULL;
-	if (purple_blist_node_get_string(PURPLE_BLIST_NODE(buddy), "email")) {
-		PurpleMenuAction *action = purple_menu_action_new(_("Email Buddy"), PURPLE_CALLBACK(mm_send_email_cb), NULL, NULL);
-		menu = g_list_append(menu, action);
-	}
-	return menu;
+
+//	GHashTable *components = purple_chat_get_components(PURPLE_CHAT(bnode));
+//	const gchar *channel_id = g_hash_table_lookup(components, "id");
+
+//	PurpleAccount *pa = purple_chat_get_account(chat);
+//	PurpleConnection *pc = purple_account_get_connection(pa);
+//	MattermostAccount *ma = purple_connection_get_protocol_data(pc);
+
+    //FIXME: bnode does not point to our chat ? why ?
+//	mm_send_file(pc, who, NULL); 
 }
+*/
 
 static GList *
-mm_blist_node_menu(PurpleBlistNode *node)
+mm_blist_node_menu(PurpleBlistNode *bnode)
 {
-	if(PURPLE_BUDDY(node)) {
-		return mm_buddy_menu((PurpleBuddy *) node);
-	}
-	return NULL;
+	GList *menu = NULL;
+
+	if(PURPLE_IS_BUDDY(bnode)) {
+		PurpleMenuAction *action = purple_menu_action_new(_("Email Buddy"), PURPLE_CALLBACK(mm_send_email_menu_cb), NULL, NULL);
+		menu = g_list_append(menu, action);
+	} else if (PURPLE_IS_CHAT(bnode)) {
+		//FIXME: bnode is not NULL here but ... points to nowhere ?
+		//PurpleMenuAction *action = purple_menu_action_new(_("Send File"), PURPLE_CALLBACK(mm_send_file_menu_cb), NULL, NULL);
+		//menu = g_list_append(menu, action);
+	} 
+	
+	return menu;
 }
 
 static const gchar *
@@ -753,6 +768,14 @@ mm_about_server(PurpleProtocolAction *action)
 	} else {
 		purple_notify_user_info_add_pair_plaintext(user_info,_("Public file links"),_("disabled"));
 	}
+
+	if(ma->client_config->enable_file_attachments) {
+		purple_notify_user_info_add_pair_plaintext(user_info,_("File attachments"),_("enabled"));
+	} else {
+		purple_notify_user_info_add_pair_plaintext(user_info,_("File attachments"),_("disabled"));
+	}
+
+	purple_notify_user_info_add_pair_plaintext(user_info,_("Max file size"), g_strdup_printf("%" G_GINT64_FORMAT, ma->client_config->max_file_size));
 
 	purple_notify_user_info_add_section_break(user_info);
 
@@ -1406,18 +1429,26 @@ mm_get_client_config_response(MattermostAccount *ma, JsonNode *node, gpointer us
 
 	JsonObject *response = json_node_get_object(node);
 
-	if (json_object_get_string_member(response,"EnablePublicLink"), "true") {
+	if (purple_strequal(json_object_get_string_member(response,"EnablePublicLink"), "true")) {
 		ma->client_config->public_link = TRUE; 
 	} else {
 		ma->client_config->public_link = FALSE;
 	}
 
-	if (json_object_get_string_member(response,"EnableCommands"), "true") {
+	if (purple_strequal(json_object_get_string_member(response,"EnableCommands"), "true")) {
 		ma->client_config->enable_commands = TRUE;
 	} else {
 		ma->client_config->enable_commands = FALSE;
 	}
 
+	if (purple_strequal(json_object_get_string_member(response,"EnableFileAttachments"), "true")) {
+		ma->client_config->enable_file_attachments = TRUE;
+	} else {
+		ma->client_config->enable_file_attachments = FALSE;
+	}
+
+	ma->client_config->max_file_size = g_ascii_strtoll(json_object_get_string_member(response,"MaxFileSize"),NULL,10);
+	if (ma->client_config->max_file_size == 0) ma->client_config->max_file_size = MATTERMOST_MAX_FILE_SIZE;
 	ma->client_config->site_name = g_strdup(json_object_get_string_member(response,"SiteName"));
 	ma->client_config->support_email = g_strdup(json_object_get_string_member(response,"SupportEmail"));
 	ma->client_config->server_version = g_strdup(json_object_get_string_member(response,"Version"));
@@ -2745,6 +2776,7 @@ mm_login(PurpleAccount *account)
 	ma->client_config = g_new0(MattermostClientConfig,1);
 	ma->client_config->public_link = FALSE;
 	ma->client_config->enable_commands = FALSE;
+	ma->client_config->enable_file_attachments = FALSE;
 
 	ma->one_to_ones = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 	ma->one_to_ones_rev = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
@@ -3830,11 +3862,11 @@ static gint
 mm_conversation_send_message(MattermostAccount *ma, const gchar *team_id, const gchar *channel_id, const gchar *message, GList *file_ids);
 
 static void
-mm_coversation_send_image_response(MattermostAccount *ma, JsonNode *node, gpointer user_data)
+mm_conversation_send_file_response(MattermostAccount *ma, JsonNode *node, gpointer user_data)
 {
 	const gchar *channel_id = user_data;
 
-	if (!mm_check_mattermost_response(ma,node,_("Error"),_("Error uploading image file"),TRUE)) return;
+	if (!mm_check_mattermost_response(ma,node,_("Error"),_("Error uploading file"),TRUE)) return;
 
 	JsonObject *response = json_node_get_object(node);
 	JsonArray *file_infos = json_object_get_array_member(response,"file_infos");
@@ -3842,25 +3874,30 @@ mm_coversation_send_image_response(MattermostAccount *ma, JsonNode *node, gpoint
 	for (i=0; i < len ; i++) {
 		JsonObject *file_info = json_node_get_object(json_array_get_element(file_infos, i));
 		const gchar *file_id = json_object_get_string_member(file_info,"id");
-
+		
 		GList *file_ids = NULL;
 		file_ids = g_list_append(file_ids,g_strdup(file_id));
-		mm_conversation_send_message(ma, NULL, channel_id, "", file_ids);
+    const gchar *name = purple_url_decode(json_object_get_string_member(file_info,"name"));
+
+		//we send an empty message here with just file_ids
+
+ 	  mm_conversation_send_message(ma, NULL, channel_id, "", file_ids);
+
+    if (g_hash_table_lookup(ma->group_chats, channel_id)) {
+      purple_serv_got_chat_in(ma->pc, g_str_hash(channel_id), "[purple-mattermost]" , PURPLE_MESSAGE_SYSTEM|PURPLE_MESSAGE_RECV, g_strconcat("file sent (",name,")",NULL), time(NULL));
+    } 
 	}
 }
 static void
-mm_conversation_send_image(MattermostAccount *ma,const gchar *channel_id, PurpleImage *image)
+mm_conversation_send_file(MattermostAccount *ma,const gchar *channel_id, const gchar *filename, gpointer buffer, gint64 len)
 {
-	gchar *url, *postdata;
-	const gchar *filename = purple_image_get_path(image);
-
-	postdata = g_memdup(purple_image_get_data(image),purple_image_get_size(image));
-
-	url = mm_build_url(ma,"/files?channel_id=%s&filename=%s",channel_id,filename);
-	mm_fetch_url(ma, url, MATTERMOST_HTTP_POST, postdata, purple_image_get_size(image), mm_coversation_send_image_response, g_strdup(channel_id));
+	gchar *url;
+	//URL filename - encode !!
+	url = mm_build_url(ma,"/files?channel_id=%s&filename=%s",channel_id,purple_url_encode(filename));
+	mm_fetch_url(ma, url, MATTERMOST_HTTP_POST, buffer, len, mm_conversation_send_file_response, g_strdup(channel_id));
 
 	g_free(url);
-	g_free(postdata);
+	g_free(buffer);
 }
 
 //FIXME: merge two funcs below.
@@ -3894,7 +3931,12 @@ mm_conversation_send_files(MattermostAccount *ma, const gchar *team_id, const gc
 		int imgid = mm_conversation_find_imageid(msgpt);
 
 		PurpleImage *image = purple_image_store_get(imgid);
-		if (image) {mm_conversation_send_image(ma, channel_id, image);}
+		if (image) {
+			const gchar *filename = purple_image_get_path(image);
+			gint64 len = purple_image_get_size(image);
+			gchar *buffer = g_memdup(purple_image_get_data(image),len);
+			mm_conversation_send_file(ma, channel_id, filename, buffer, len);
+		}
 
 		msgpt = g_strstr_len(msgpt, strlen(msgpt), ">");
 		if (msgpt != NULL) { msgpt = msgpt + 1; }
@@ -3945,7 +3987,6 @@ mm_conversation_send_message(MattermostAccount *ma, const gchar *team_id, const 
 
 	postdata = json_object_to_string(data);
 
-	//url = mm_build_url(ma,"/teams/%s/channels/%s/posts/create", team_id, channel_id);
 	url = mm_build_url(ma,"/posts");
 	mm_fetch_url(ma, url, MATTERMOST_HTTP_POST, postdata, -1, mm_conversation_send_message_response, NULL); //todo look at callback
 
@@ -4617,6 +4658,23 @@ mm_cmd_leave(PurpleConversation *conv, const gchar *cmd, gchar **args, gchar **e
 	return PURPLE_CMD_RET_OK;
 }
 
+static PurpleCmdRet
+mm_cmd_sendfile(PurpleConversation *conv, const gchar *cmd, gchar **args, gchar **error, gpointer data)
+{
+  const gchar *who;
+
+	PurpleConnection *pc = purple_conversation_get_connection(conv);
+
+  if (purple_conversation_get_type(conv) == PURPLE_CONV_TYPE_CHAT) {
+    who = purple_conversation_get_data(conv, "id");
+    mm_send_file(pc, who, NULL);
+
+    return PURPLE_CMD_RET_OK;
+  } 
+
+  return PURPLE_CMD_RET_FAILED;
+}
+
 static void
 mm_slash_command_response(MattermostAccount *ma, JsonNode *node, gpointer user_data)
 {
@@ -4663,7 +4721,7 @@ mm_slash_command(PurpleConversation *conv, const gchar *cmd, gchar **args, gchar
 
 	if (PURPLE_IS_IM_CONVERSATION(conv)) {
 		purple_notify_error(pc, _("Error"), _("Not implemented."), 
-														_("Slash commands not implemented (yet) for private channels."), purple_request_cpar_from_connection(pc));
+														_("Slash commands not implemented (yet) for direct channels."), purple_request_cpar_from_connection(pc));
 		return PURPLE_CMD_RET_FAILED;
 	}
 
@@ -4735,6 +4793,12 @@ plugin_load(PurplePlugin *plugin, GError **error)
 						MATTERMOST_PLUGIN_ID, mm_cmd_leave,
 						_("leave:  Leave the channel"), NULL);
 
+  // Send file cannot be enabled somehow in chats ...
+  purple_cmd_register("sendfile", "", PURPLE_CMD_P_PLUGIN, PURPLE_CMD_FLAG_CHAT |
+						PURPLE_CMD_FLAG_PROTOCOL_ONLY | PURPLE_CMD_FLAG_ALLOW_WRONG_ARGS,
+						MATTERMOST_PLUGIN_ID, mm_cmd_sendfile,
+						_("sendfile:  Upload a file to the channel"), NULL);
+
 	return TRUE;
 
 }
@@ -4746,6 +4810,78 @@ plugin_unload(PurplePlugin *plugin, GError **error)
 
 	return TRUE;
 }
+
+static void mm_send_file_xfer(PurpleXfer *xfer)
+{
+	const gchar *channel_id = NULL;
+
+	PurpleAccount *pa = purple_xfer_get_account(xfer);
+	PurpleConnection *pc = purple_account_get_connection(pa);
+	MattermostAccount *ma = purple_connection_get_protocol_data(pc);
+
+
+	xfer->filename = g_path_get_basename(xfer->local_filename);
+
+	channel_id=g_hash_table_lookup(ma->one_to_ones_rev,xfer->who);
+
+	if (channel_id == NULL) channel_id= xfer->who; // this comes from group channel
+
+	if (xfer->size > ma->client_config->max_file_size) {
+		purple_notify_error(ma->pc, _("Error"), _("Error sending file"), _("Selected file size is bigger than max file size."), purple_request_cpar_from_connection(ma->pc));
+		purple_xfer_cancel_local(xfer);
+		return;
+	}
+
+	FILE *fp = fopen(purple_xfer_get_local_filename(xfer),"rb");
+	gpointer *buffer = g_try_malloc(xfer->size);
+
+	if (fp == NULL) {
+		purple_notify_error(ma->pc, _("Error"), _("Error sending file"), _("Cannot open file."), purple_request_cpar_from_connection(ma->pc));
+		purple_xfer_cancel_local(xfer);
+		return;
+	}
+
+	if (buffer == NULL) {
+		purple_notify_error(ma->pc, _("Error"), _("Error sending file"), _("Cannot allocate memory."), purple_request_cpar_from_connection(ma->pc));
+		purple_xfer_cancel_local(xfer);
+		return;
+	}
+
+	if (!fread(buffer, xfer->size, 1, fp)) {
+		purple_notify_error(ma->pc, _("Error"), _("Error sending file"), _("Cannot read file."), purple_request_cpar_from_connection(ma->pc));
+		purple_xfer_cancel_local(xfer);
+		fclose(fp);
+		return;
+	}
+
+	fclose(fp);
+
+	xfer->bytes_sent = xfer->size;
+	xfer->bytes_remaining = 0;
+	xfer->start_time = time(NULL);
+	xfer->end_time = xfer->start_time;
+
+	mm_conversation_send_file(ma,channel_id,xfer->filename,buffer,xfer->size);
+
+	purple_xfer_set_completed(xfer, TRUE);
+	purple_xfer_end(xfer);
+	purple_xfer_unref(xfer);
+	//g_free(buffer); in mm_conversation_send_file
+}
+
+static void
+mm_send_file(PurpleConnection *pc, const char *who, const char *file) 
+{
+
+	PurpleXfer *xfer = purple_xfer_new(purple_connection_get_account(pc), PURPLE_XFER_SEND, who);
+
+	if (xfer) {
+		purple_xfer_set_init_fnc(xfer, mm_send_file_xfer);
+		purple_xfer_request(xfer);
+	} 
+}
+
+
 
 // Purple2 Plugin Load Functions
 #if !PURPLE_VERSION_CHECK(3, 0, 0)
@@ -4771,6 +4907,7 @@ libpurple2_plugin_unload(PurplePlugin *plugin)
 
 	return plugin_unload(plugin, NULL);
 }
+
 
 static void
 plugin_init(PurplePlugin *plugin)
@@ -4836,6 +4973,8 @@ plugin_init(PurplePlugin *plugin)
 
 	prpl_info->roomlist_get_list = mm_roomlist_get_list;
 	prpl_info->roomlist_room_serialize = mm_roomlist_serialize;
+
+	prpl_info->send_file = mm_send_file;
 }
 
 

--- a/libmattermost.h
+++ b/libmattermost.h
@@ -36,6 +36,7 @@
 #define MATTERMOST_HISTORY_PAGE_SIZE 60 // 200 is MAX in paged queries (60 is default)
 #define MATTERMOST_MAX_PAGES 10 // that is 2000 users or posts in paged queries
 
+#define MATTERMOST_MAX_FILE_SIZE 52428800 // default MM max limit for attachments
 #define MATTERMOST_DEFAULT_SERVER ""
 #define MATTERMOST_SERVER_SPLIT_CHAR '|'
 
@@ -116,6 +117,7 @@ typedef struct {
 typedef struct {
 	gboolean public_link;
 	gboolean enable_commands;
+	gboolean enable_file_attachments;
 	gchar *site_name;
 	gchar *site_url;
 	gchar *support_email;
@@ -125,6 +127,7 @@ typedef struct {
 	gchar *build_hash;
 	gchar *build_date;
 	gchar *enterprise_ready;
+	gint64 max_file_size;
 } MattermostClientConfig;
 
 typedef struct {


### PR DESCRIPTION
Since we can send images , lets extend it and allow sending any files to chat/im conversations: unfortunately somehow adding ui menu to chat 'Conversation' menu does not work (lines ~ 379) , therefore in chats files can be sent using '/sendfile' command while in im convs -> using Conversation -> Send File menu ...