### PR TITLE
show link to post when file links are disabled

### DIFF
--- a/libmattermost-helpers.c
+++ b/libmattermost-helpers.c
@@ -101,6 +101,7 @@ mm_g_free_mattermost_channel_link(gpointer a)
 	MattermostChannelLink *l = a;
 	g_free(l->channel_id);
 	g_free(l->file_id);
+	g_free(l->post_id);
 	g_free(l->sender);
 	g_free(l);
 }

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -1709,8 +1709,18 @@ mm_file_metadata_response(MattermostAccount *ma, JsonNode *node, gpointer user_d
 
 	//TODO: that file can have thumbnail, display it ? ...
 	if (!mmfile->uri || !ma->client_config->public_link) {
-		//TODO: get proper team name here, maybe based on channel, if available
-		const gchar *team_name = g_hash_table_lookup(ma->teams, mm_get_first_team_id(ma));
+		// get team_id for this channel, if possible
+		const gchar *team_id = NULL;
+		if (mmfile->mmchlink->channel_id) {
+			team_id = g_hash_table_lookup(ma->channel_teams, mmfile->mmchlink->channel_id);
+		}
+
+		// if there is no channel id or the lookup failed, use first team_id
+		if (!team_id) {
+			team_id = mm_get_first_team_id(ma);
+		}
+
+		const gchar *team_name = g_hash_table_lookup(ma->teams, team_id);
 		gchar *url = g_strconcat((purple_account_get_bool(ma->account, "use-ssl", TRUE)?"https://":"http://"), ma->server,"/", team_name, "/pl/", mmfile->mmchlink->post_id, NULL);
 		anchor = g_strconcat("[error: public links disabled on server, cannot get file: ",mmfile->name,", visit ","<a href=\"", url, "\">", url, "</a> to access the file]" , NULL);
 		g_free(url);

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -1721,9 +1721,15 @@ mm_file_metadata_response(MattermostAccount *ma, JsonNode *node, gpointer user_d
 		}
 
 		const gchar *team_name = g_hash_table_lookup(ma->teams, team_id);
-		gchar *url = g_strconcat((purple_account_get_bool(ma->account, "use-ssl", TRUE)?"https://":"http://"), ma->server,"/", team_name, "/pl/", mmfile->mmchlink->post_id, NULL);
-		anchor = g_strconcat("[error: public links disabled on server, cannot get file: ",mmfile->name,", visit ","<a href=\"", url, "\">", url, "</a> to access the file]" , NULL);
-		g_free(url);
+		gchar *link_error_str = g_strconcat("[error: public links disabled on server, cannot get file: ",mmfile->name, NULL);
+		if (team_name) {
+			gchar *url = g_strconcat((purple_account_get_bool(ma->account, "use-ssl", TRUE)?"https://":"http://"), ma->server,"/", team_name, "/pl/", mmfile->mmchlink->post_id, NULL);
+			anchor = g_strconcat(link_error_str, ", visit ","<a href=\"", url, "\">", url, "</a> to access the file]" , NULL);
+			g_free(url);
+		} else {
+			anchor = g_strconcat(link_error_str, "]", NULL);
+		}
+		g_free(link_error_str);
 	} else {
 		if (!anchor) anchor = g_strconcat("<a href=\"", mmfile->uri, "\">", mmfile->name, "</a>", NULL);
 	}

--- a/libmattermost.h
+++ b/libmattermost.h
@@ -263,18 +263,19 @@ typedef struct {
 typedef struct {
 	gchar *channel_id;
 	gchar *file_id;
+	gchar *post_id;
 	gchar *sender;
 	gint64 timestamp;
 } MattermostChannelLink;
 
 typedef struct {
-		gchar *id;
+	gchar *id;
 //	gchar *user_id;
 //	gchar *post_id;
 	gchar *name;
 //	gchar *extension;
 //	gint64 size;
-		gchar *mime_type;
+	gchar *mime_type;
 //	gint width;
 //	gint height;
 	gboolean has_preview_image;


### PR DESCRIPTION
When public links are disabled on a server, there is just an error message `[error: public links disabled on server, cannot get file: test.txt]`. I've added a permalink to the post containing the file so that it can be easily accessed in this case. Please check whether this is the right way to create the url, I'm not sure how the team_id really works for individual chats.