### PR TITLE
Mark deleted messaged in conversation

### DIFF
--- a/libmattermost.c
+++ b/libmattermost.c
@@ -1874,13 +1874,17 @@ mm_process_room_message(MattermostAccount *ma, JsonObject *post, JsonObject *dat
 
 			g_free(msg_pre);
 			g_free(msg_post);
-		
-			if (json_object_get_int_member(post, "edit_at")) {
+
+			if (json_object_get_int_member(post, "delete_at")) {
+				gchar *tmp = g_strconcat(_("Deleted: "), message, NULL);
+				g_free(message);
+				message = tmp;
+			} else if (json_object_get_int_member(post, "edit_at")) {
 				gchar *tmp = g_strconcat(_("Edited: "), message, NULL);
 				g_free(message);
 				message = tmp;
 			}
-			
+
 			if (json_object_has_member(post, "file_ids")) {
 				JsonArray *file_ids = json_object_get_array_member(post, "file_ids");
 				guint i, len = json_array_get_length(file_ids);


### PR DESCRIPTION
When deleted messages are shown (usually when read from history), mark them as deleted