### PR TITLE
fix: edited message renders emoji

### DIFF
--- a/libmattermost.c
+++ b/libmattermost.c
@@ -1946,11 +1946,11 @@ mm_process_room_message(MattermostAccount *ma, JsonObject *post, JsonObject *dat
 			g_free(msg_post);
 
 			if (json_object_get_int_member(post, "delete_at")) {
-				gchar *tmp = g_strconcat(_("Deleted: "), message, NULL);
+				gchar *tmp = g_strconcat(_("Deleted : "), message, NULL);
 				g_free(message);
 				message = tmp;
 			} else if (json_object_get_int_member(post, "edit_at")) {
-				gchar *tmp = g_strconcat(_("Edited: "), message, NULL);
+				gchar *tmp = g_strconcat(_("Edited : "), message, NULL);
 				g_free(message);
 				message = tmp;
 			}


### PR DESCRIPTION
**Problem**
When someone edits a post, it should render as
```
Edited: <updated_message>
``` 
but, it actually renders as
![image](https://user-images.githubusercontent.com/33994932/109000390-a98c9980-76c9-11eb-8c8b-de9afab66a20.png)

