### PR TITLE
set mmfile uri if not set

### DIFF
--- a/libmattermost.c
+++ b/libmattermost.c
@@ -1801,9 +1801,7 @@ mm_fetch_file_metadata(MattermostAccount *ma, JsonNode *node, gpointer user_data
 	g_free(url);
 
 	if (!mmfile->uri) {
-		url = mm_build_url(ma, "/files/%s", mmfile->mmchlink->file_id);
-		mmfile->uri = g_strdup(url);
-		g_free(url);
+		mmfile->uri = mm_build_url(ma, "/files/%s", mmfile->mmchlink->file_id);
 	}
 }
 

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -1799,6 +1799,12 @@ mm_fetch_file_metadata(MattermostAccount *ma, JsonNode *node, gpointer user_data
 	mm_fetch_url(ma, url, MATTERMOST_HTTP_GET, NULL, -1, mm_file_metadata_response, mmfile);
 
 	g_free(url);
+
+	if (!mmfile->uri) {
+		url = mm_build_url(ma, "/files/%s", mmfile->mmchlink->file_id);
+		mmfile->uri = g_strdup(url);
+		g_free(url);
+	}
 }
 
 static void


### PR DESCRIPTION
When there is no uri on mmfile set one. It works pretty well in my environment where we have server without public links. It presents the direct link onto the file which is more comfortable than opening the whole web client I think.