### PR TITLE
Add cache message comment

### DIFF
--- a/libmattermost.c
+++ b/libmattermost.c
@@ -1892,7 +1892,11 @@ mm_message_cache_find(MattermostAccount *ma,
 
 	if (!msgp) return NULL;
 
-	// todo move to the actual to the front of the queue
+	// Move the actualy commented message to the front of the
+	// queue. We asume that commented message will probably be
+	// commented again thus we don't wanna loase such message.
+	g_queue_unlink(ma->message_cache, msgp);
+	g_queue_push_head_link(ma->message_cache, msgp);
 
 	return msgp->data;
 

--- a/libmattermost.h
+++ b/libmattermost.h
@@ -179,6 +179,8 @@ typedef struct {
 	GHashTable *teams_display_names; // an descriptive names too.
 	GHashTable *channel_teams;    // A list of channel_id -> team_id to know what team a channel is in
 	GQueue *received_message_queue; // A store of the last 10 received message id's for de-dup
+
+	GQueue *message_cache;        // A store of the message for comments preambule
 	
 	GList *user_prefs;            // all user preferences read from server
 	GList *joined_channels;       // all channels for which we performed mm_join_room and have not left;


### PR DESCRIPTION
I have added simple cache queue for author and message abstract. This cache is used to add the preambule with author and commented message abstract. It makes conversations with comments more readable.