### PR TITLE
[Feature]: Fetch last 60 messages when a channel is joined for the first time from Pidgin.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
 
       - name: Install System dependencies
         run: |
+          sudo apt-get update -y
           sudo apt-get install libpurple-dev libjson-glib-dev libglib2.0-dev gettext git make libmarkdown2-dev build-essential mingw-w64 mercurial p7zip-full nsis
 
       - name: Download Pidgin and Build dependencies

--- a/libmattermost.c
+++ b/libmattermost.c
@@ -2227,7 +2227,7 @@ mm_process_attachment(JsonObject *attachment)
 }
 
 static gint64
-mm_get_channel_approximate_view_time(MattermostAccount *ma, gchar *id)
+mm_get_channel_approximate_view_time(MattermostAccount *ma, const gchar *id)
 {
 	gchar *tmptime = NULL;
 
@@ -3735,7 +3735,8 @@ mm_get_history_of_room(MattermostAccount *ma, MattermostChannel *channel, gint64
 	if (!channel->id) return;
 
 	if (since < 0) {
-		since = mm_get_channel_approximate_view_time(ma, channel->id);
+		const gchar *channel_id = channel->id;
+		since = mm_get_channel_approximate_view_time(ma, channel_id);
 	}
 
 	if (since == MATTERMOST_NEW_CHANNEL_FOUND) {

--- a/libmattermost.h
+++ b/libmattermost.h
@@ -33,8 +33,10 @@
 
 #define MATTERMOST_BUFFER_DEFAULT_SIZE 40960
 #define MATTERMOST_USER_PAGE_SIZE 200 // 200 is MAX. in paged queries (and default)
-#define MATTERMOST_HISTORY_PAGE_SIZE 60 // 200 is MAX in paged queries (60 is default)
+#define MATTERMOST_HISTORY_PAGE_SIZE 60 // 200 is MAX in paged queries (60 is default) also used to fetch last 60 messages for a new channel
 #define MATTERMOST_MAX_PAGES 10 // that is 2000 users or posts in paged queries
+
+#define MATTERMOST_NEW_CHANNEL_FOUND -2 // -2 indicates that timestamp does not exist for a new channel
 
 #define MATTERMOST_DEFAULT_SERVER ""
 #define MATTERMOST_SERVER_SPLIT_CHAR '|'


### PR DESCRIPTION
**Features:**

- Fetch the last 60 messages when a channel is joined for the first time.

Steps to test:
- Join a new channel from Pidgin and the joined channel room will automatically open and fetch the last 60 messages(if exists)

- When another user adds a Pidgin(Mattermost user using Pidgin) user to a channel on Mattermost then that channel room will automatically open and fetch the last 60 messages(if exists)

**Bug fixes/Improvements**

- When a Pidgin(Mattermost user using Pidgin) user was added to a channel on Mattermost by another user then that channel was visible in the Pidgin rooms list but the user was not able to open that channel room on Pidgin until restarting it, now it is fixed and the user doesn't need to restart the Pidgin app to open a newly added channel/room.